### PR TITLE
fix: prevent chart distortion from repeated scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,8 +263,8 @@ function drawLineChart(canvas, series, options){
   if (canvas.width !== Math.round(cssW*DPR) || canvas.height !== Math.round(cssH*DPR)){
     canvas.width = Math.round(cssW*DPR); canvas.height = Math.round(cssH*DPR);
   }
-  const W = canvas.width, H = canvas.height;
-  ctx.scale(DPR, DPR);
+  // reset any existing transforms to avoid cumulative scaling on redraws
+  ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
 
   ctx.clearRect(0,0,cssW,cssH);
   if (!series.length){ ctx.fillStyle="#7a8aa0"; ctx.fillText("Nessun dato", 12, 20); return; }


### PR DESCRIPTION
## Summary
- reset canvas transform each redraw to avoid cumulative scaling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897bb485edc832296e3f99ae5bb5601